### PR TITLE
Systemd unit for delayed_job

### DIFF
--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -1,0 +1,13 @@
+- name: stop monit service
+  service:
+    name: delayed_job_{{ app }}
+    state: stopped
+  become: yes
+  become_user: root
+
+- name: remove monit package
+  apt:
+    pkg: monit
+    state: absent
+  become: yes
+  become_user: root

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -33,13 +33,19 @@
     - libxslt1-dev
     - memcached
     - ranger
-    - monit
+    #- monit
     #- fontconfig # needed for phantomjs
     #- nfs-common # make virtualbox faster
   tags: packages
 
-- name: configure monit
-  template:
-    src=monit.j2
-    dest=/etc/monit/conf.d/{{ app }}
+# Remove monit if still installed. The notified handlers will run only once
+# (when the main task triggers a change by removing the config file)
+- name: clean up monit
+  file:
+    state: absent
+    path: /etc/monit/conf.d/{{ app }}
   become: yes
+  become_user: root
+  notify:
+    - stop monit service
+    - remove monit package

--- a/roles/common/templates/monit.j2
+++ b/roles/common/templates/monit.j2
@@ -1,9 +1,0 @@
-check process openfoodnetwork_dj_worker_0
-  with pidfile {{ current_path }}/tmp/pids/delayed_job.0.pid
-  start program = "/bin/bash -c 'RAILS_ENV={{ rails_env }} {{ unicorn_home_path }}/.rbenv/shims/ruby {{ current_path }}/script/delayed_job -i 0 start'"
-  as uid {{ unicorn_user }} and gid {{ unicorn_user }}
-  with timeout 120 seconds
-  stop program = "/bin/bash -c 'RAILS_ENV={{ rails_env }} {{ unicorn_home_path }}/.rbenv/shims/ruby {{ current_path }}/script/delayed_job -i 0 stop'"
-  as uid {{ unicorn_user }} and gid {{ unicorn_user }}
-  with timeout 120 seconds
-  if mem is greater than 250.0 MB for 3 cycles then restart

--- a/roles/deploy/handlers/main.yml
+++ b/roles/deploy/handlers/main.yml
@@ -11,11 +11,12 @@
 - name: precompile nondigest assets
   command: bash -lc "bundle exec rake assets:precompile:nondigest RAILS_GROUPS=assets RAILS_ENV={{ rails_env }}" chdir="{{ current_path }}"
 
-
-
-- name: restart delayed job workers
-  command:  bash -lc "./script/delayed_job -i 0 stop RAILS_ENV={{ rails_env }}" chdir="{{ current_path }}"
-
+- name: restart delayed job service
+  service:
+    name: delayed_job_{{ app }}
+    state: restarted
+  become: yes
+  become_user: root
 
 - name: restart unicorn
   command: psql -h {{ db_host }} -U {{ db_user }} -d {{ db }} -c "SELECT true FROM pg_tables WHERE tablename = 'order_cycles';"

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -185,7 +185,7 @@
   notify:
     - precompile assets
     - restart unicorn
-    - restart delayed job workers
+    - restart delayed job service
 
 - name: seed database
   # We run a shell script that passes the default email and password to rake with an EOF block, so we don't hang on the prompts.
@@ -200,7 +200,6 @@
     - precompile assets
     - restart unicorn
 
-
 # tag to trigger a unicorn restart
 - name: reset
   # needs to do something here
@@ -210,3 +209,4 @@
     - skip_ansible_lint
   notify:
     - restart unicorn
+    - restart delayed job service

--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -28,4 +28,5 @@
   service:
     name: "delayed_job_{{ app }}"
     enabled: yes
+  become: yes
   tags: init

--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -24,6 +24,12 @@
   become: yes
   tags: init
 
+- name: Reload systemd
+  shell: systemctl daemon-reload
+  become: yes
+  become_user: root
+  tags: init
+
 - name: Enable delayed_job unit
   service:
     name: "delayed_job_{{ app }}"

--- a/roles/webserver/templates/delayed_job.service.j2
+++ b/roles/webserver/templates/delayed_job.service.j2
@@ -4,14 +4,15 @@
 Description=Open Food Network delayed_job
 
 [Service]
-Type=simple
-User=openfoodnetwork
-WorkingDirectory={{ current_path }}
-Environment=RAILS_ENV={{ rails_env }}
-SyslogIdentifier=openfoodnetwork-delayed_job
+Type=forking
 PIDFile={{ delayed_job_pid }}
-
-ExecStart=script/delayed_job
+RemainAfterExit=no
+Restart=on-failure
+RestartSec=60s
+User=openfoodnetwork
+SyslogIdentifier=openfoodnetwork-delayed_job
+ExecStart=/bin/bash -c "RAILS_ENV={{ rails_env }} {{ unicorn_home_path }}/.rbenv/shims/ruby {{ current_path }}/script/delayed_job start --pid-dir={{ pid_path }}"
+ExecStop=/bin/bash -c "RAILS_ENV={{ rails_env }} {{ unicorn_home_path }}/.rbenv/shims/ruby {{ current_path }}/script/delayed_job stop --pid-dir={{ pid_path }}"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I've finished off the work to make a functioning systemd unit for delayed_job:

![screenshot from 2018-07-13 21-42-22](https://user-images.githubusercontent.com/9029026/42713018-cfbadc42-86e5-11e8-905c-7fb52b8edd4b.png)

**Too Long; Didn't Review:**

- The command in ExecStart= always has to have an _absolute_ path
- We need to use forking mode, as the script is daemonising
- We need to call Ruby via rbenv to run the script, and it needs to be aware of the pid folder location
- We also need to run `sudo systemctl daemon-reload` after any changes to systemd unit files, or they won't work when updated
- systemd is smart enough to restart a correctly-configured service, so we can ditch monit now and just use `Restart=on-failure` from within the systemd unit itself


![italian-hand-gif](https://media.giphy.com/media/qiPkUKtSqR7qw/giphy.gif)